### PR TITLE
fix: use PkgConfig::ZMQ with PUBLIC linkage and override macOS dynami…

### DIFF
--- a/faiss/CMakeLists.txt
+++ b/faiss/CMakeLists.txt
@@ -488,27 +488,35 @@ if(FAISS_USE_LTO)
 endif()
 
 find_package(OpenMP REQUIRED)
-target_link_libraries(faiss PRIVATE OpenMP::OpenMP_CXX
-${ZeroMQ_LIBRARIES}       # Add ZMQ
-${MSGPACK_LIBRARIES}      # Add msgpack-c
+
+# Link faiss static library with PUBLIC linkage to ZMQ
+# PUBLIC because faiss source code uses ZMQ headers AND consumers must link ZMQ
+target_link_libraries(faiss
+  PUBLIC PkgConfig::ZMQ           # PUBLIC: faiss uses ZMQ and propagates to consumers
+  PRIVATE OpenMP::OpenMP_CXX
+  PRIVATE ${MSGPACK_LIBRARIES}
 )
 if(FAISS_BUILD_AVX_VERSIONS)
-  target_link_libraries(faiss_avx2 PRIVATE OpenMP::OpenMP_CXX
-  ${ZeroMQ_LIBRARIES}       # Add ZMQ
-  ${MSGPACK_LIBRARIES}      # Add msgpack-c
+  target_link_libraries(faiss_avx2
+    PUBLIC PkgConfig::ZMQ
+    PRIVATE OpenMP::OpenMP_CXX
+    PRIVATE ${MSGPACK_LIBRARIES}
   )
-  target_link_libraries(faiss_avx512 PRIVATE OpenMP::OpenMP_CXX
-  ${ZeroMQ_LIBRARIES}       # Add ZMQ
-  ${MSGPACK_LIBRARIES}      # Add msgpack-c
+  target_link_libraries(faiss_avx512
+    PUBLIC PkgConfig::ZMQ
+    PRIVATE OpenMP::OpenMP_CXX
+    PRIVATE ${MSGPACK_LIBRARIES}
   )
-  target_link_libraries(faiss_avx512_spr PRIVATE OpenMP::OpenMP_CXX
-  ${ZeroMQ_LIBRARIES}       # Add ZMQ
-  ${MSGPACK_LIBRARIES}      # Add msgpack-c
+  target_link_libraries(faiss_avx512_spr
+    PUBLIC PkgConfig::ZMQ
+    PRIVATE OpenMP::OpenMP_CXX
+    PRIVATE ${MSGPACK_LIBRARIES}
   )
 endif()
-target_link_libraries(faiss_sve PRIVATE OpenMP::OpenMP_CXX
-${ZeroMQ_LIBRARIES}       # Add ZMQ
-${MSGPACK_LIBRARIES}      # Add msgpack-c
+target_link_libraries(faiss_sve
+  PUBLIC PkgConfig::ZMQ
+  PRIVATE OpenMP::OpenMP_CXX
+  PRIVATE ${MSGPACK_LIBRARIES}
 )
 
 if(FAISS_ENABLE_MKL)

--- a/faiss/python/CMakeLists.txt
+++ b/faiss/python/CMakeLists.txt
@@ -247,12 +247,21 @@ endif()
 
 find_package(OpenMP REQUIRED)
 
+# ZMQ is now linked transitively through faiss (PUBLIC linkage)
 target_link_libraries(swigfaiss PRIVATE
-  faiss
+  faiss                  # This will automatically link ZMQ::zmq transitively
   Python::Module
   Python::NumPy
   OpenMP::OpenMP_CXX
 )
+
+# macOS: Python::Module adds -undefined dynamic_lookup which prevents actual linking
+# Override to use proper symbol resolution and force ZMQ linkage
+if(APPLE)
+  set_target_properties(swigfaiss PROPERTIES
+    LINK_FLAGS "-Wl,-undefined,error"
+  )
+endif()
 
 if(FAISS_BUILD_AVX_VERSIONS)
   target_link_libraries(swigfaiss_avx2 PRIVATE


### PR DESCRIPTION
## Summary

Fixes ZMQ linking issues that cause `ImportError: symbol not found '_zmq_close'` during editable installs.

## Problem

- Editable installs failed with `ImportError` for ZMQ symbols
- PyPI wheel installations worked fine
- macOS Python::Module adds `-undefined dynamic_lookup` which defers symbol resolution
- ARM64 Mac was finding Intel Homebrew ZMQ instead of ARM64 version

## Root Cause

1. Missing `IMPORTED_TARGET` in `pkg_check_modules`
2. macOS `-undefined dynamic_lookup` flag deferred symbol resolution
3. Incorrect architecture-specific ZMQ library detection

## Solution

- Used `pkg_check_modules IMPORTED_TARGET` to create proper CMake targets
- Set `PKG_CONFIG_PATH` to prioritize ARM64 Homebrew on Apple Silicon
- Overrode macOS `-undefined dynamic_lookup` to force symbol resolution at build time
- Used PUBLIC linkage for ZMQ in faiss library for transitive dependencies

## Testing

- ✅ Editable install now works
- ✅ Python extension imports successfully
- ✅ All ZMQ symbols resolved at build time

## Related

This fix is required for LEANN PR [#150 (metadata output feature)](ww2283:feature/add-metadata-output) and PR [#152](https://github.com/yichuan-w/LEANN/pull/152) (Ollama batching optimization).